### PR TITLE
Update get-flax.md to fix grammatical errors

### DIFF
--- a/manual/get-started/get-flax.md
+++ b/manual/get-started/get-flax.md
@@ -1,10 +1,10 @@
-# Installing Flax Launcher
+# Installing The Flax Launcher
 
 ![Installing Flax](media/installing-flax.png)
 
-To get Flax visit [download page](http://flaxengine.com/download) and access the Flax Launcher applciation installer.
+To get Flax visit the [download page](http://flaxengine.com/download) and access the Flax Launcher applciation installer.
 
-After downloading the Flax installer start the application and follow the installation wizard steps. In order to install Flax you will be asked to accept *EULA* that defines the engine licensing terms. You can learn more about legal regulations [here](http://flaxengine.com/licensing).
+After downloading the Flax installer start the application and follow the installation wizard steps. In order to install Flax you will be asked to accept the *EULA* that defines the engine licensing terms. You can learn more about legal regulations [here](http://flaxengine.com/licensing).
 
 To learn more about software and hardware requirements please visit [this page](requirements.md).
 
@@ -14,11 +14,11 @@ Do you have a mouse? Yes? Ok, great. Now double click on **Flax** icon on your d
 
 ![Login To Flax Launcher](media/flax-launcher-login.png)
 
-The next step is to **log in** to the Flax Launcher. Simply use the same account credential you used to access the installer. Your account is required to verify if you can download the engine builds from our digital distribution. Launcher supports *Offline mode* in case you want to create games without Internet access, far from civilization (far in the forest or on the sea).
+The next step is to **log in** to the Flax Launcher. Simply use the same account credentials you used to access the installer. Your account is required to verify if you can download the engine builds from our digital distribution. The launcher supports *Offline mode* in case you want to create games without Internet access, far from civilization (far in the forest or on the sea).
 
 ![Open Launcher](media/launcher-engine.jpg)
 
-After you log in go to the **Engine** page. It is used to download and managed engine installations. You can have multiple different versions on Flax installed on your computer. Here you can add new updates and download additional packages. To install Flax use **Add Version** button. Then select the version and a target installation destination folder. You can also pick a target platform to install. Those packages are required if you want to build and deploy your game for a given platform. Finally, you can press **Install** button and wait for just a second to download Flax binaries.
+After you log in go to the **Engine** page. It is used to download and manage engine installations. You can have multiple versions of Flax installed on your computer. Here you can add new updates and download additional packages. To install Flax click the **Add Version** button then select the version and a target installation destination folder. You can also pick a target platform to install if you want to build and deploy your game for a different platform. Finally, you can click the **Install** button and wait for just a second to download the Flax binaries.
 
 > [!Note]
 > The engine version with a blue outline is marked as default to open projects. Use the context menu on it (3 dots) to set another version as default or to modify its properties.


### PR DESCRIPTION
Some grammatical errors fixed.

There may need to be some changes to the line: "Simply use the same account credentials you used to access the installer."
When I downloaded the installer I did not have to enter any credentials so this may be outdated information?