### PR TITLE
Add a simple high-dpi documentation

### DIFF
--- a/manual/ui/high-dpi/index.md
+++ b/manual/ui/high-dpi/index.md
@@ -1,0 +1,19 @@
+# High DPI UI
+
+Modern screens have increasingly high pixel densities, meaning more pixels in the same area. Such screens are called high DPI (dots per inch) screens.  To make UIs have the correct size on such screens, you have to introduce a DPI adjustment. 
+
+For example, with a DPI scale of 200%, all UI pixels become twice as large as the pixels on the screen.
+
+For the most part, you don't have to do anything and Flax takes care of everything for you. 
+
+## Screen Space
+
+One pixel in screen space is exactly one pixel on the screen. Screen space also stretches across all monitors.
+
+## Window Space
+
+Window space starts in the top left corner of the window, excluding the title-bar. For FlaxEngine UIs, this is always DPI-adjusted.
+
+## Local Space
+
+Local space starts in the top left corner of the control. It is also DPI-adjusted.

--- a/manual/ui/index.md
+++ b/manual/ui/index.md
@@ -30,6 +30,7 @@ The **UI** is one of the most important components of the games. Flax Games UI s
  * [Tiles Panel](controls/tiles-panel.md)
 * [Fonts](fonts/index.md)
 * [Text Render](text-render/index.md)
+* [High DPI](high-dpi/index.md)
 * [Tutorials](tutorials/index.md)
 
 ## Tutorials


### PR DESCRIPTION
This adds a rather short documentation page for high DPI stuff. Eventually, it might be worthwhile to document FlaxEngine windows and then make this a sub-page of that.

Fix #26