### PR TITLE
Remove Improve this Doc from C# API pages

### DIFF
--- a/api/index.md
+++ b/api/index.md
@@ -4,6 +4,7 @@ _tocRel: toc.html
 _navPath: toc.html
 _navRel: ../toc.html
 _tocTitle: 'API'
+_disableContribution: true
 ---
 
 # Flax API


### PR DESCRIPTION
Found this in the styles checklist in the doc roadmap.
![Check](https://user-images.githubusercontent.com/70076725/106339379-6541e100-6264-11eb-8f7e-02828567f078.PNG)

Is this working?

![Sample1](https://user-images.githubusercontent.com/70076725/106339417-81458280-6264-11eb-93f7-6a4aa21100b2.PNG)

![Sample2](https://user-images.githubusercontent.com/70076725/106339418-8276af80-6264-11eb-8e73-f47c3df80047.PNG)
