### PR TITLE
Update index.md

### DIFF
--- a/manual/get-started/flax-for-unity-devs/index.md
+++ b/manual/get-started/flax-for-unity-devs/index.md
@@ -16,7 +16,7 @@ Flax Editor and Unity Editor are very similar. You can see the color-coded, high
 ![Flax Editor](../media/flax-layout.png)
 
 > [!Tip]
-> You don't have to pay or buy any *Pro* version to have a *Dark Theme* in the Flax Editor.
+> Flax ships with a nice *Dark Theme* by default. No need to go into your settings to fix that.
 
 ## Terminology
 


### PR DESCRIPTION
We can't flex on Unity's paid dark theme anymore, but at least we still have dark-by-default.

If Flax gets a built-in light theme, it'd be interesting to automatically pick the correct theme based on what the OS says.