### PR TITLE
Minor improvements to Flax.Build documentation

### DIFF
--- a/manual/editor/flax-build/api-tags.md
+++ b/manual/editor/flax-build/api-tags.md
@@ -2,14 +2,14 @@
 
 ## API_CLASS(...)
 
-Use it on class to expose it to the scripting API. You can specify custom attributes in the braces.
+Use it on a class to expose it to the scripting API. You can specify custom attributes in the braces.
 Example:
 
 ```cpp
 /// <summary>
 /// Actor that links to the animated model skeleton node transformation.
 /// </summary>
-API_CLASS(sealed) class BoneSocket : public Actor
+API_CLASS(Sealed) class BoneSocket : public Actor
 {
 ...
 }
@@ -17,7 +17,7 @@ API_CLASS(sealed) class BoneSocket : public Actor
 
 ## API_PROPERTY(...)
 
-Use it on the property getter/setter methods to expose property to the scripting API. You can specify custom attributes in the braces.
+Use it on the property getter/setter methods to expose the property to the scripting API. You can specify custom attributes in the braces.
 Example:
 
 ```cpp
@@ -41,7 +41,7 @@ void SetUseScale(bool value);
 
 ## API_FIELD(...)
 
-Use it on the field to expose property to the scripting API. You can specify custom attributes in the braces.
+Use it on a field to expose it to the scripting API. You can specify custom attributes in the braces.
 Example:
 
 ```cpp
@@ -54,7 +54,7 @@ float Scale = 1.0f;
 
 ## API_FUNCTION(...)
 
-Use it on the function to expose property to the scripting API. You can specify custom attributes in the braces.
+Use it on a function to expose it to the scripting API. You can specify custom attributes in the braces.
 Example:
 
 ```cpp
@@ -67,7 +67,7 @@ void UpdateTransformation();
 
 ## API_PARAM(...)
 
-Use it on the function parameters to adjust the parameter convertion between scripting and native.
+Use it on the function parameters to adjust the parameter conversion between scripting and native.
 Example:
 
 ```cpp
@@ -86,7 +86,7 @@ API_EVENT() Delegate<float> SpeedChanged;
 
 ## API_AUTO_SERIALIZATION()
 
-Use it inside class or structure to generate automatic object data serialization code for `ISerializable` interface.
+Use it inside a class or structure to generate automatic object data serialization code for `ISerializable` interface.
 Example:
 
 ```cpp
@@ -100,12 +100,12 @@ DECLARE_SCRIPTING_TYPE_NO_SPAWN(ToneMappingSettings);
 
 ## Tag parameters
 
-Tag attributes tha can be added to the API tags braces to edjust the bindigns logic:
+Tag attributes that can be added to the API tags braces to adjust the bindings logic:
 
 * `Static` - marks the method/class/property to not use instance of the object but be static in code
 * `Sealed` - makes the class to be final and blocks inheritance
 * `Abstract` - makes the class to be abstract (cannot create object of it, can be only inherited)
-* `Public`/`Protected`/`Private` - access levels specified for methods/classes/properties to define the visibility in the scritping API
+* `Public`/`Protected`/`Private` - access levels specified for methods/classes/properties to define the visibility in the scripting API
 * `InBuild` - marks type (class, struct, enum) as in-build into scripting API (skips generation by assuming it's already in the bindings API)
 * `Attributes="..."` - adds a custom attributes to the generated type or member that are added to C# types attributes
 * `ReadOnly` - makes the field in class as read-only (only getter will be generated, no setter)
@@ -122,10 +122,11 @@ Tag attributes tha can be added to the API tags braces to edjust the bindigns lo
 ### Array&lt;T&gt;
 
 If property or method uses native Array&lt;T&gt; as input or output it will be interpreted as T[] in scripting.
-Also, the bindings generator will implement atomatic convertion between native and managed object type (including copy operation).
+Also, the bindings generator will implement automatic conversion between native and managed object type (including copy operation).
 If you want to return an array of items from native method you can return it by value (eg. `API_FUNCTION() Array<Guid> GetIds()`). Bindings generator will convert it into managed array (supported types for array elements are value types, enums, strings and scripting objects such as actors, scripts, assets pointers, object references).
 
 ### Dictionary&lt;KeyType, ValueType&gt;
 
 If property or method uses native Dictionary&lt;KeyType, ValueType&gt; as input or output it will be interpreted as System.Collections.Generic.Dictionary&lt;KeyType, ValueType&gt; in scripting.
-Also, the bindings generator will implement atomatic convertion between native and managed object type (including copy operation).
+Also, the bindings generator will implement automatic conversion between native and managed object type (including copy operation).
+

--- a/manual/editor/flax-build/index.md
+++ b/manual/editor/flax-build/index.md
@@ -2,12 +2,13 @@
 
 ![Flax.Build build tool](media/title.jpg)
 
-**Flax.Build** is an in-build utility which is a complete build system written in C#. It supports:
+**Flax.Build** is an in-built utility which is a complete build system written in C#. It supports:
+
 * compiling and linking of engine, game and tools projects
 * downloading and pre-building engine dependencies
-* updating 3rd Party libraries
+* updating 3rd party libraries
 * generating project files
-* deploying engine
+* deploying the engine
 * generating C# bindings for native code.
 
 Major features:
@@ -17,13 +18,13 @@ Major features:
 * extensibility via plugins
 * multi-platform support.
 
-This documentation section covers most of the topics related to Flax.Build tool. To learn more please refer to Flax.Build sources located under `Source\Tools\Flax.Build` and/or use `Binaries\Tools\Flax.Build.exe -help` to learn more about usage. Engine repository contains useful scripts that are wrappers against the build tool and automatically compile its sources.
+This documentation section covers most of the topics related to Flax.Build tool. To learn more please refer to Flax.Build sources located under `Source\Tools\Flax.Build` and/or use `Binaries\Tools\Flax.Build.exe -help` to learn more about usage. The engine repository contains useful scripts that are wrappers against the build tool and automatically compile its sources.
 
 ## Build Scripts
 
-The main source of build configuration are **.Build.cs** files located in the project `Source` directory. Written in **C#** scripts can contain targets, modules, SDKs, or other utilities used for building. When generating project scripts files all build scripts are included in **Rules** project which defines the build rules and can be explored with code IDE.
+The main source of build configuration are **.Build.cs** files located in the project `Source` directory. Written in **C#**, scripts can contain targets, modules, SDKs, or other utilities used for building. When generating project scripts files, all build scripts are included in **Rules** project which defines the build rules and can be explored with code IDE.
 
-Build scripts are using C# 7.2 with full .Net 4.5 support. Additionally Flax.Build assembly is referenced with many usefull utilities to use during build setup like:
+Build scripts are using C# 7.2 with full .Net 4.5 support. Additionally Flax.Build assembly is referenced with many useful utilities to use during build setup like:
 * `CommandLine` attribute for command line parsing
 * `Log` utility with info/errors logging capabilities (to log file and to console output)
 * `Tokenizer` class for pasing code as tokens
@@ -35,7 +36,7 @@ Using build scripts you can automate many processes related to game/engine/plugi
 
 ## Targets and Modules
 
-Build **Target** is a script that combines modules to produce a final executable file or composite library. Build **Module** is a script that can be compiled from source and used by other modules and targets. Targets in general define the global build environment (eg. global definitions) and include modules into the binary build. Modules are chunks of code compiled into binaries linked later into a target output binary (eg. game executable file). Modules can have references between each other for example if a game script wants to create GPU Texture resource, the game module needs to reference the Graphics module that implements a GPU texture.
+A build **Target** is a script that combines modules to produce a final executable file or composite library. A [build **Module**](../../scripting/tutorials/add-scripts-module.md) is a script that can be compiled from source and used by other modules and targets. Targets in general define the global build environment (eg. global definitions) and include modules into the binary build. Modules are chunks of code compiled into binaries linked later into a target output binary (eg. game executable file). Modules can have references between each other for example if a game script wants to create GPU Texture resource, the game module needs to reference the Graphics module that implements a GPU texture.
 
 Using modules can greatly improve code readability, allow to split huge codebase into more independent chunks, and they help to organize the structure of the project sources. Modules can be referenced in `Setup` method which means they can have conditional references (eg. Profiler module is not included in Release builds).
 
@@ -98,7 +99,7 @@ Additionally, all build scripts are included in **BuildScripts** C# project whic
 
 ## Platforms Support
 
-Flax.Build is a **multiplatform** utility thas has been battle-tested on Windows and Linux to build engine and games to the different target platforms including Windows, PS4, XboxOne, XboxScarlett, Linux, UWP. Each target platform implementation is stored in a separate directory under `Source\Tools\Flax.Build\Platforms` and contain **Platform** implementation and **Toolchain** implementation. Different platforms can use external SDKs, toolsets, or custom compilers to build code for a runtime.
+Flax.Build is a **multiplatform** utility that has been battle-tested on Windows and Linux to build engine and games to the different target platforms including Windows, PS4, XboxOne, XboxScarlett, Linux, UWP. Each target platform implementation is stored in a separate directory under `Source\Tools\Flax.Build\Platforms` and contain **Platform** implementation and **Toolchain** implementation. Different platforms can use external SDKs, toolsets, or custom compilers to build code for a runtime.
 
 Also, engine dependency packages contain automatic build scripts to prepare pre-build deps for development. When adding new platform support many deps packages have to be ported too. The related code can be found in `Source\Tools\Flax.Build\Deps\Dependencies` folder.
 

--- a/manual/editor/flax-build/plugins.md
+++ b/manual/editor/flax-build/plugins.md
@@ -1,8 +1,8 @@
-# Plugins
+# Build Plugins
 
-Flax.Build allows to extend it by using custom **Plugins**. Each plugin can deliver custom build system tasks, platform integration, scripting language support, or code IDE support.
+Flax.Build allows you to extend it by using custom **Plugins**. Each plugin can deliver custom build system tasks, platform integration, scripting language support, or code IDE support.
 
-To create a plugin simply add build script file somewhere in the `Source` folder of your project (`<name>.Build.cs`). Then write a class that inherits from `Flax.Build.Plugin` as follows:
+To create a plugin, simply add build script file somewhere in the `Source` folder of your project (`<name>.Build.cs`). Then write a class that inherits from `Flax.Build.Plugin` as follows:
 
 ```cs
 using Flax.Build;
@@ -14,10 +14,10 @@ class MyPlugin : Plugin
     {
         base.Init();
 
-        // Here you can implement custom logic...
+        // Here you can implement custom building logic...
         Log.Info("Hello from plugin!");
     }
 }
 ```
 
-Plugins are initialized before any build/clean/projects actions so you can use them to register custom logic into the build tool. Follow Flax.Build code docuemntation to learn more. As an example, Visual Scripting integration into the engine is using **VisualScriptingPlugin** to inject custom virtual methods wrappers code.
+Plugins are initialized before any build/clean/projects actions so you can use them to register custom logic into the build tool. Follow the Flax.Build code documentation to learn more. As an example, the Visual Scripting integration uses the **VisualScriptingPlugin** to inject custom virtual method wrappers code.


### PR DESCRIPTION
A few small improvements here and there to the Flax.Build documentation.

Most importantly, this PR adds a link to `add-scripts-module.md` from the Flax.Build documentation and changes the title of the build plugins to `Build Plugins`