### PR TITLE
Hosting on github io with automatic rebuilds

### DIFF
--- a/.github/workflows/docs-build-publish.yml
+++ b/.github/workflows/docs-build-publish.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Checkout live docs repo
         uses: actions/checkout@v2
         with:
-          repository: honzapatCZ/flaxdocs-host
+          repository: FlaxEngine/flaxdocs-host
           path: _site
           fetch-depth: 1
           persist-credentials: false
@@ -58,5 +58,5 @@ jobs:
           github_token: ${{ secrets.API_TOKEN_GITHUB }}
           branch: ${{ github.ref }}
           directory: _site
-          repository: honzapatCZ/flaxdocs-host
+          repository: FlaxEngine/flaxdocs-host
           force: true

--- a/.github/workflows/docs-build-publish.yml
+++ b/.github/workflows/docs-build-publish.yml
@@ -7,48 +7,56 @@ on:
 
 jobs:
   build:
-
     runs-on: ubuntu-18.04
 
     steps:
-    - name: Checkout repo
-      uses: actions/checkout@v1
-      with:
-        path: docs
-        fetch-depth: 1
+      - name: Checkout repo
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 1
 
-    - name: Get mono
-      run: |
-        apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF
-        echo "deb https://download.mono-project.com/repo/ubuntu stable-bionic main" | sudo tee /etc/apt/sources.list.d/mono-official-stable.list
-        sudo apt-get update
-        sudo apt-get install mono-complete --yes
+      - name: Checkout live docs repo
+        uses: actions/checkout@v2
+        with:
+          repository: honzapatCZ/flaxdocs-host
+          path: _site
+          fetch-depth: 1
+          persist-credentials: false
 
-    - name: Get docfx
-      run: |
-        curl -L https://github.com/dotnet/docfx/releases/latest/download/docfx.zip -o docfx.zip
-        unzip -d .docfx docfx.zip
+      - name: Clear live docs repo
+        run: rm -rf _site/*
 
-    - name: Build docs
-      run:  mono .docfx/docfx.exe
-   
-    - name: Checkout live docs repo
-      uses: actions/checkout@v1
-      with:
-        repository: honzapatCZ/flaxdocs-host
-        ref: master
-        fetch-depth: 1
-        path: docs/live
-		
-    - name: Clear live docs repo
-      run: rm -rf live/*
-	  
-    - name: Commit and push
-      run: |
-        cd live
-        git config --global user.email "noreply@nejcraft.cz"
-        git config --global user.name "Automated System"
-        git add .
-        git commit -m "Automated update" --author $GITHUB_ACTOR
-        header=$(echo -n "ad-m:$" | base64)
-        git -c http.extraheader="AUTHORIZATION: basic $header" push origin HEAD:master
+      - name: Get mono
+        run: |
+          sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF
+          sudo sh -c 'echo "deb https://download.mono-project.com/repo/ubuntu stable-bionic main" > /etc/apt/sources.list.d/mono-official-stable.list'
+          sudo apt-get update
+          sudo apt-get install mono-complete --yes
+
+      - name: Get docfx
+        run: |
+          curl -L https://github.com/dotnet/docfx/releases/latest/download/docfx.zip -o docfx.zip
+          unzip -d .docfx docfx.zip
+
+      - name: Build docs
+        run: mono .docfx/docfx.exe
+        
+      - name: Commit
+        run: |
+          export GIT_COMMITTER_NAME=$(git show -s --format='%cn')
+          export GIT_COMMITTER_EMAIL=$(git show -s --format='%ce')
+          export GIT_AUTHOR_NAME=$(git show -s --format='%an')
+          export GIT_AUTHOR_EMAIL=$(git show -s --format='%ae')
+          export COMMIT_HASH=$(git show -s --format='%H')
+          export SUBJECT=$(git show -s --format='%s')
+          cd _site
+          git add .
+          git commit -m "$SUBJECT" -m "Original commit: $COMMIT_HASH"
+      - name: Push changes
+        uses: ad-m/github-push-action@master
+        with:
+          github_token: ${{ secrets.API_TOKEN_GITHUB }}
+          branch: ${{ github.ref }}
+          directory: _site
+          repository: honzapatCZ/flaxdocs-host
+          force: true

--- a/.github/workflows/docs-build-publish.yml
+++ b/.github/workflows/docs-build-publish.yml
@@ -1,0 +1,54 @@
+name: Build Documentation
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  build:
+
+    runs-on: ubuntu-18.04
+
+    steps:
+    - name: Checkout repo
+      uses: actions/checkout@v1
+      with:
+        path: docs
+        fetch-depth: 1
+
+    - name: Get mono
+      run: |
+        apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF
+        echo "deb https://download.mono-project.com/repo/ubuntu stable-bionic main" | sudo tee /etc/apt/sources.list.d/mono-official-stable.list
+        sudo apt-get update
+        sudo apt-get install mono-complete --yes
+
+    - name: Get docfx
+      run: |
+        curl -L https://github.com/dotnet/docfx/releases/latest/download/docfx.zip -o docfx.zip
+        unzip -d .docfx docfx.zip
+
+    - name: Build docs
+      run:  mono .docfx/docfx.exe
+   
+    - name: Checkout live docs repo
+      uses: actions/checkout@v1
+      with:
+        repository: honzapatCZ/flaxdocs-host
+        ref: master
+        fetch-depth: 1
+        path: docs/live
+		
+    - name: Clear live docs repo
+      run: rm -rf live/*
+	  
+    - name: Commit and push
+      run: |
+        cd live
+        git config --global user.email "noreply@nejcraft.cz"
+        git config --global user.name "Automated System"
+        git add .
+        git commit -m "Automated update" --author $GITHUB_ACTOR
+        header=$(echo -n "ad-m:$" | base64)
+        git -c http.extraheader="AUTHORIZATION: basic $header" push origin HEAD:master


### PR DESCRIPTION
After the burn down of data center, this actually seems like a good idea
There are few steps to get this working
Create a repo under FlaxEngine called **flaxdocs-host**, give some bot (like flaxtechnology) write access, generate his **Private Access Key** and add that key to this repositorys secrets as **API_TOKEN_GITHUB**
Setup github pages for flaxdocs-host under the root(optionally forward domain)
And **merge this PR**
