### PR TITLE
Updated links and the requirements section.

### DIFF
--- a/manual/get-started/requirements.md
+++ b/manual/get-started/requirements.md
@@ -16,18 +16,20 @@ Flax Engine has specific hardware and software requirements for running the game
 
 For developers using Flax Editor on Linux platforms the requirements are [here](linux.md).
 
-## Software
+## Software Requirements
 
-Flax Engine requires **Visual C++ Redistributable for Visual Studio 2015** to be installed on Windows in order to start. Flax Launcher will check for the missing package and begin installation, however if your game is targeting the Windows platform you should include the redistributable installer with it.
+Flax Engine requires **Visual C++ Redistributable for Visual Studio 2015** to be installed on Windows in order to start.\
+The launcher will check and begin installation if it is missing, however if your game is targeting the Windows platform you should include the redistributable installer with it. You can download it [here](https://www.microsoft.com/download/details.aspx?id=48145).
 
-Flax Launcher requires [Microsoft .NET Framework 4 Client Profile](http://www.microsoft.com/pl-pl/download/details.aspx?id=24872) or higher.
-We also recommend using Visual Studio 2013, 2015, 2017 or 2019 for writing code.
-You can get free version [here](https://www.visualstudio.com/downloads/).
+Flax Launcher requires [Microsoft .NET Framework 4 Client Profile](http://www.microsoft.com/download/details.aspx?id=24872) or higher.
+
+We also recommend using Visual Studio 2017 or 2019 for writing code.\
+You can download the free community edition [here](https://www.visualstudio.com/downloads/).
 
 ## GPU Drivers
 
-Please ensure to have the latest GPU drivers installed. Helper links:
-- [NVIDIA drivers](http://www.nvidia.com/Download/index.aspx?lang=en-us/)
-- [AMD drivers](http://support.amd.com/en-us/download)
+Please ensure that you have the latest GPU drivers installed:
+- [NVIDIA drivers](https://www.nvidia.com/Download/index.aspx)
+- [AMD drivers](https://www.amd.com/support)
 
 For information about supported platforms, see [Platforms](../platforms/index.md).


### PR DESCRIPTION
Changed all the external links to be free of language selection, so that the respective sites can redirect you to the appropriate page for your language rather than defaulting to English (or Polish in the case of the framework link). Also AMD has changed their support location from support.amd.com to amd.com/support, so that's been updated too.

Rewrote, reformatted and renamed the software section, and included a link to the 2015 Redistributable, since the page recommends you include it with games targeting Windows. If nothing else it'll save people a bit of time googling.

The visual studio section was shortened to include only 2017 and 2019 since that's what the extension supports (also 2013 and 2015 is woefully out of date. 2015 don't even support C# 7.0 without weird hacks), and also specified that the community edition is what people should be downloading, since the linked page also offers VS professional and enterprise as "free trials".

Minor change to drivers section too, no need for "helper links" since the heading is clear enough already.