### PR TITLE
Add tip for Unity devs about Flax's coordinate system not using meters

### DIFF
--- a/manual/get-started/flax-for-unity-devs/index.md
+++ b/manual/get-started/flax-for-unity-devs/index.md
@@ -61,6 +61,9 @@ Just instead of using `GetComponent<T>()` in your scripts, write `GetChild<T>()`
 
 In Flax, Scene object is also an Actor so you can access it like any other Actor. This means that Scenes can have their own scripts and be transformed like other objects.
 
+> [!Tip]
+> Flax's coordinate system's base unit is centimeters instead of meters, meaning a Flax Actor placed at <100,100,100> is in the equivalent position of a Unity Transform placed at <1,1,1>.
+
 ## MonoBehaviour vs Script
 
 When it comes to game scripting, Unity and Flax are very similar. There are some differences in C# API (Flax has bigger math library, is more performance-oriented and uses new C# 7.2). In fact, the whole C# editor and C++ engine including scripting API is open and can be found [here](https://github.com/FlaxEngine/FlaxEngine). All contributions are welcome.


### PR DESCRIPTION
I just downloaded Flax today, and then started messing around to get a bit of a feel for the editor and how things work. One thing that I found really odd was that my default cube (scale of 1 on all axes) was positioned at what I assumed to be 50 meters from the world origin, despite its 1 meter-wide edge still reaching the origin.

I then read through the [Flax for Unity devs](https://github.com/FlaxEngine/FlaxDocs/blob/master/manual/get-started/flax-for-unity-devs/index.md) page which didn't make any mention of differences in coordinate systems, so I asked on the Discord server. It was pointed out to me that Flax's coordinate system's base unit is centimeters (compared to meters in Unity), which seems so obvious now that I know.

I've added a little tip to the Flax for Unity devs page which should hopefully save others the same confusion I just experienced. I put it under the GameObject vs Actor section as this seemed like the best fit out of the existing sections, but I can move it elsewhere if that's preferred.