### PR TITLE
Added required packages for Linux

### DIFF
--- a/manual/scripting/cpp/index.md
+++ b/manual/scripting/cpp/index.md
@@ -31,6 +31,7 @@ Flax Editor contains a build-in C# compiler for scripts but for C\+\+ scripting 
 
 * Install [Visual Studio Code](https://code.visualstudio.com/)
 * Get the compiler `sudo apt-get install clang lldb lld` (Clang 6 or newer)
+* Install required dependencies `libxcursor-dev libxinerama-dev libx11-dev`
 
 ### Mac
 


### PR DESCRIPTION
Without these packages, you won't be able to build `libGame.HotReload.6.so` on Linux (when recompiling scripts in a project containing C++ scripts).

Note: These are also dependencies for building Flax Engine, so if you have built it from source you will naturally not notice this issue, as you will already have them installed. It happened to me when using the pre-built Linux editor here: https://vps2.flaxengine.com/store/builds/Package_1_04_06334/FlaxEditorLinux.zip.
Installing these dependencies fixed the problem for me.

Using `ldd` I've verified that `libGame.HotReload.6.so` depends on these libraries.