### PR TITLE
Replace usage of Deinitialize in EditorPlugin examples

### DIFF
--- a/manual/editor/advanced/custom-visject-surface.md
+++ b/manual/editor/advanced/custom-visject-surface.md
@@ -91,12 +91,12 @@ public class ExpressionGraphPlugin : EditorPlugin
     }
 
     /// <inheritdoc />
-    public override void Deinitialize()
+    public override void DeinitializeEditor()
     {
     	// Cleanup on plugin deinit
         Editor.ContentDatabase.Proxy.Remove(_expressionGraphProxy);
 
-        base.Deinitialize();
+        base.DeinitializeEditor();
     }
 }
 ```

--- a/manual/scripting/advanced/custom-editor-options.md
+++ b/manual/scripting/advanced/custom-editor-options.md
@@ -50,12 +50,12 @@ public class TestPlugin : EditorPlugin
         Debug.Log("Editor options: " + options.TimerName + ", " + options.TimerValue);
     }
 
-    public override void Deinitialize()
+    public override void DeinitializeEditor()
     {
     	// Cleanup on end
         Editor.Options.RemoveCustomSettings(SettingsName);
 
-        base.Deinitialize();
+        base.DeinitializeEditor();
     }
 }
 ```

--- a/manual/scripting/tutorials/custom-editor-settings.md
+++ b/manual/scripting/tutorials/custom-editor-settings.md
@@ -52,13 +52,13 @@ public class MyCustomPlugin : EditorPlugin
     }
 
     /// <inheritdoc />
-    public override void Deinitialize()
+    public override void DeinitializeEditor()
     {
         // Ensure to cleanup on plugin shutdown
         Editor.Options.OptionsChanged -= OnOptionsChanged;
         Editor.Options.RemoveCustomSettings(SettingsType);
 
-        base.Deinitialize();
+        base.DeinitializeEditor();
     }
 }
 ```

--- a/manual/scripting/tutorials/custom-plugin.md
+++ b/manual/scripting/tutorials/custom-plugin.md
@@ -40,7 +40,7 @@ namespace ExamplePlugin
         }
 
         /// <inheritdoc />
-        public override void Deinitialize()
+        public override void DeinitializeEditor()
         {
             if (_button != null)
             {
@@ -48,7 +48,7 @@ namespace ExamplePlugin
                 _button = null;
             }
 
-            base.Deinitialize();
+            base.DeinitializeEditor();
         }
     }
 }
@@ -57,7 +57,7 @@ namespace ExamplePlugin
 
 
 
-Flax plugins use two main methods for the lifetime: `Initialize` and `Deinitialize`. However for Editor plugins when `Initialize` is called the Editor may still be uninitialized so it's better to use `InitializeEditor` to add custom GUI to the Editor.
+Flax plugins use two main methods for the lifetime: `InitializeEditor` and `DeinitializeEditor`.
 
 ### 3. Test it out
 


### PR DESCRIPTION
In most of the cases if you were going to keep using `Deinitialize` in editor plugins to deinitialize stuff you would get scripting binding segfaults, so it is better to unify the API usage, just like migration guide is proposing to do.