### PR TITLE
Fix the link to .NET SDK 7 on requirements.md

### DIFF
--- a/manual/get-started/requirements.md
+++ b/manual/get-started/requirements.md
@@ -27,7 +27,7 @@ The launcher will check and begin installation if it is missing, however if your
 
 Flax Launcher requires [Microsoft .NET Framework 4.5.2](https://www.microsoft.com/en-us/download/details.aspx?id=42642) or higher.
 
-Flax Editor requires [.NET SDK 7](ttps://dotnet.microsoft.com/en-us/download/dotnet/7.0).
+Flax Editor requires [.NET SDK 7](https://dotnet.microsoft.com/en-us/download/dotnet/7.0).
 
 We also recommend using Visual Studio 2022 for writing code.
 You can download the free community edition [here](https://www.visualstudio.com/downloads/).


### PR DESCRIPTION
The link to the download of .NET SDK 7 is missing a "h" on "ttps://..."