### PR TITLE
Add info on how to get a reference to a game plugin

### DIFF
--- a/manual/scripting/plugins/index.md
+++ b/manual/scripting/plugins/index.md
@@ -148,7 +148,7 @@ Your game can also use a Game Plugins within a code to implement various gamepla
 
 You can now get a reference to your Game Plugin with:
 ```cs
-MyPlugin gamePlugin = PluginManager.GetPlugin<>(MyPlugin);
+MyPlugin gamePlugin = PluginManager.GetPlugin<MyPlugin>();
 ```
 
 To make access to the plugin easier, you can define a property in your MyPlugin class like this:

--- a/manual/scripting/plugins/index.md
+++ b/manual/scripting/plugins/index.md
@@ -151,19 +151,9 @@ You can now get a reference to your Game Plugin with:
 MyPlugin gamePlugin = PluginManager.GetPlugin<MyPlugin>();
 ```
 
-To make access to the plugin easier, you can define a property in your MyPlugin class like this:
+To make access to the plugin easier, you can define an Instance property in your MyPlugin class like this:
 ```cs
-public static MyPlugin Instance 
-{
-    get 
-    {   
-        if (_instance == null)
-            _instance = PluginManager.GetPlugin<MyPlugin>();
-
-        return _instance;
-    }
-}
-private static MyPlugin _instance;
+public static MyPlugin Instance { get => PluginManager.GetPlugin<MyPlugin>(); }
 ```
 
 Now you can access the Game Plugin like this:

--- a/manual/scripting/plugins/index.md
+++ b/manual/scripting/plugins/index.md
@@ -144,6 +144,33 @@ void MyPlugin::Deinitialize()
 
 Your game can also use a Game Plugins within a code to implement various gameplay features because plugins don't rely on loaded scenes or scene objects and are created before the scenes loading (compared to the normal scripts).
 
+### How to get your Game Plugin
+
+You can now get a reference to your Game Plugin with:
+```cs
+MyPlugin gamePlugin = PluginManager.GetPlugin<>(MyPlugin);
+```
+
+To make access to the plugin easier, you can define a property in your MyPlugin class like this:
+```cs
+public static MyPlugin Instance 
+{
+    get 
+    {   
+        if (_instance == null)
+            _instance = PluginManager.GetPlugin<MyPlugin>();
+
+        return _instance;
+    }
+}
+private static MyPlugin _instance;
+```
+
+Now you can access the Game Plugin like this:
+```cs
+MyPlugin gamePlugin  = MyPlugin.Instance;
+```
+
 ### Game Plugin Settings
 
 If you need to include custom settings for your plugin see [this tutorial](../tutorials/custom-settings.md) to learn more.


### PR DESCRIPTION
If anyone more experienced with C# notices a potential issue with the `Instance` property, please point them out. So far this has worked perfectly fine for me though.

This also is a pattern that's used throughout the Flax source code, so I think it's fine to suggest that here.

![image](https://github.com/user-attachments/assets/d35bc672-7254-4fa3-9094-861074565d0b)
